### PR TITLE
remove version numbers from components

### DIFF
--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -1,5 +1,5 @@
-import QtQuick		2.12
-import JASP.Module	1.0
+import QtQuick
+import JASP.Module
 
 Description
 {

--- a/inst/qml/Data.qml
+++ b/inst/qml/Data.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick			2.8
-import QtQuick.Layouts	1.3
-import JASP.Controls	1.0
-import JASP.Widgets		1.0
-import JASP				1.0
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+import JASP.Widgets
+import JASP
 
 Form
 {

--- a/inst/qml/Integer.qml
+++ b/inst/qml/Integer.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick			2.8
-import QtQuick.Layouts	1.3
-import JASP.Controls	1.0
-import JASP.Widgets		1.0
-import JASP				1.0
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+import JASP.Widgets
+import JASP
 
 Form
 {

--- a/inst/qml/Parabola.qml
+++ b/inst/qml/Parabola.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick			2.8
-import QtQuick.Layouts	1.3
-import JASP.Controls	1.0
-import JASP.Widgets		1.0
-import JASP				1.0
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+import JASP.Widgets
+import JASP
 
 Form
 {

--- a/inst/qml/Table.qml
+++ b/inst/qml/Table.qml
@@ -15,11 +15,11 @@
 // License along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 //
-import QtQuick			2.8
-import QtQuick.Layouts	1.3
-import JASP.Controls	1.0
-import JASP.Widgets		1.0
-import JASP				1.0
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+import JASP.Widgets
+import JASP
 
 Form
 {


### PR DESCRIPTION
Starting from 0.95, it is no longer necessary to specify the version number.