### PR TITLE
Fixes package naming issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: jaspModule
+Package: jaspModuleTemplate
 Type: Package
 Title: A module for JASP
 Version: 0.1.0

--- a/inst/Description.qml
+++ b/inst/Description.qml
@@ -3,7 +3,7 @@ import JASP.Module
 
 Description
 {
-	name		: "jaspModule"
+	name		: "jaspModuleTemplate"
 	title		: qsTr("Jasp Module")
 	description	: qsTr("Examples for module builders")
 	version		: "0.1"


### PR DESCRIPTION
The package was internally referenced as `jaspModule`, and not `jaspModuleTemplate`.

More context (https://github.com/jasp-stats/jasp-issues/issues/3482)